### PR TITLE
[FIX] Make 'skip' parameter work properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Using `skip` parameter in `EEGParametricForwardSolution.solve` now works as expected.
+
 ## [0.3.2] - 2020-08-05
 
 ### Fixed

--- a/src/shamo/problems/forward/eeg/eeg_parametric_forward_problem.py
+++ b/src/shamo/problems/forward/eeg/eeg_parametric_forward_problem.py
@@ -135,7 +135,7 @@ class EEGParametricForwardProblem(EEGForwardProblem):
                 ("No varying parameter given. Use " "'EEGForwardProblem' instead.")
             )
         distribution = cp.J(*[distribution for _, distribution in varying])
-        absissas = distribution.sample(n_evals, rule="halton")
+        absissas = distribution.sample(n_evals + skip, rule="halton")
         if skip != 0:
             absissas = absissas[:, skip:]
         points = {

--- a/src/shamo/problems/forward/eeg/eeg_parametric_forward_problem.py
+++ b/src/shamo/problems/forward/eeg/eeg_parametric_forward_problem.py
@@ -80,7 +80,7 @@ class EEGParametricForwardProblem(EEGForwardProblem):
         # Generate evaluation points
         n_evals = kwargs.get("n_evals", 20)
         skip = kwargs.get("skip", 0)
-        eval_points = self._generate_evaluation_points(n_evals)
+        eval_points = self._generate_evaluation_points(n_evals, skip)
         # Generate problems
         sub_problems = self._generate_sub_problems(n_evals, eval_points)
         generator = (


### PR DESCRIPTION
The `skip` parameter of `EEGParametricForwardSolution` now works properly.