### PR TITLE
[FEATURE] Add mesh refinement capabilities to mesh_from_surfaces

### DIFF
--- a/docs/src/quickstart/usage/fem.rst
+++ b/docs/src/quickstart/usage/fem.rst
@@ -1,0 +1,11 @@
+Mesh generation
+===============
+
+.. toctree::
+   :maxdepth: 1
+
+   tutorials/code/fem/fem_from_labels.ipynb
+   tutorials/code/fem/fem_from_fem.ipynb
+   tutorials/code/fem/fem_from_surfaces_lc-default.ipynb
+   tutorials/code/fem/fem_from_surfaces_lc-constant.ipynb
+   tutorials/code/fem/fem_from_surfaces_lc-tissues.ipynb

--- a/docs/src/quickstart/usage/logging.rst
+++ b/docs/src/quickstart/usage/logging.rst
@@ -17,10 +17,8 @@ Then we can configure it anyway we want. To display the output in a jupyter note
    import sys
 
    stream_handler = logging.StreamHandler(sys.stdout)
-   stream_handler.setFormatter(
-       logging.Formatter("%(asctime)s - %(message)s : [%(levelname)s] %(message)s")
-   )
-   logger.add_handler(stream_handler)
+   stream_handler.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
+   logger.addHandler(stream_handler)
    logger.setLevel(logging.INFO)
 
 .. note::

--- a/docs/src/quickstart/usage/usage.rst
+++ b/docs/src/quickstart/usage/usage.rst
@@ -4,7 +4,7 @@ Usage
 .. toctree::
    :maxdepth: 1
 
-   tutorials/code/fem/fem.ipynb
+   fem
    eeg
    hd_tdcs
    logging


### PR DESCRIPTION
Now, the `mesh_from_surfaces()` method can be used to either:
- Infer the mesh size from the surfaces.
- Use a constant mesh size across the whole mesh.
- Use a constant mesh size for each tissue.

This can come handy if some tissues are of greater interest or if a tissue is particularly small.