### PR TITLE
fix: :bug: Fix broadcast error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [1.2.1] - 24-02-19
+
+### Fixed
+
+- Fixed broadcast error when checking for empty affine matrix or shape vector in the grid sampler.
+
 ## [1.2.0] - 21-10-13
 
 ### Added

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -22,7 +22,7 @@ copyright = "2020-2021, GIGA CRC In-Vivo Imaging"
 author = "Martin Grignard <mar.grignard@uliege.be>"
 
 # The full version, including alpha/beta/rc tags
-release = "1.2.0"
+release = "1.2.1"
 
 # -- General configuration ---------------------------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,12 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.2.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize =
 	{major}.{minor}.{patch}
 
 [metadata]
 name = shamo
-version = 1.2.0
+version = 1.2.1
 url = https://github.com/CyclotronResearchCentre/shamo
 author = Martin Grignard
 author-email = mar.grignard@uliege.be

--- a/src/shamo/__init__.py
+++ b/src/shamo/__init__.py
@@ -4,7 +4,7 @@ import warnings
 from shamo.core.distributions import *
 from shamo.core.fem import *
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 # Remove unnecessary warnings
 warnings.filterwarnings("ignore", category=RuntimeWarning, lineno=521)

--- a/src/shamo/core/problems/single/components/grid_sampler.py
+++ b/src/shamo/core/problems/single/components/grid_sampler.py
@@ -43,7 +43,9 @@ class CompGridSampler(CompABC):
         bool
             Return ``True`` if the grid can be used, ``False`` otherwise.
         """
-        return True if self["affine"] != [] and self["shape"] != [] else False
+        has_affine = np.array(self["affine"]).size != 0
+        has_shape = np.array(self["shape"]).size != 0
+        return has_affine and has_shape
 
     @property
     def affine(self):


### PR DESCRIPTION
Fixed broadcast error between affine and shape and empty list. This comparison was used to check if either the affine matrix or the shape vector were empty. Now, the size attribute is used.
This error arouse from newer versions of Numpy.